### PR TITLE
Fix typo in macOS setup echo

### DIFF
--- a/home/scripts/macos.sh
+++ b/home/scripts/macos.sh
@@ -21,7 +21,7 @@ defaults write com.apple.screencapture location ~/screenshots
 echo 'Set key repeat to 2'
 defaults write -g KeyRepeat -int 2
 
-echo 'Set intitinal key repeat to 15'
+echo 'Set initial key repeat to 15'
 defaults write -g InitialKeyRepeat -int 15
 
 # Always show scrollbars


### PR DESCRIPTION
## Summary
- fix typo in `macos.sh`

## Testing
- `make lint` *(fails: `shellcheck` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406723b3ac832bab78e5624e68e850