### PR TITLE
Exclude archive from shfmt check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 # Verify shell script formatting
 .PHONY: format-check
 format-check:
-	shfmt -i 2 -ci -bn -l -d .
+	git ls-files | grep -E '\\.(sh|bash|zsh|ksh)$$' | grep -v '^_archive/' | xargs shfmt -i 2 -ci -bn -l -d
 
 # Run shellcheck on relevant scripts
 # Restricts search to avoid shellchecking submodules


### PR DESCRIPTION
## Summary
- avoid formatting archived scripts during linting

## Testing
- `make lint` *(fails: shfmt reports unexpected diff)*

------
https://chatgpt.com/codex/tasks/task_e_684214a11cc0832b8663b49c137699f3